### PR TITLE
allow defining specific editor to use

### DIFF
--- a/examples/custom_editor.rs
+++ b/examples/custom_editor.rs
@@ -1,8 +1,8 @@
-use open_editor::{EditOptions, errors::OpenEditorError, open_editor_with_opts};
+use open_editor::{EditOptions, EditorKind, errors::OpenEditorError, open_editor_with_opts};
 
 fn main() -> Result<(), OpenEditorError> {
     let user_input = open_editor_with_opts(EditOptions {
-        env_vars: vec!["MY_EDITOR".to_string()],
+        editor: Some(EditorKind::Vi.into()),
         ..Default::default()
     })?;
 

--- a/examples/independant_editor.rs
+++ b/examples/independant_editor.rs
@@ -1,4 +1,4 @@
-use open_editor::editor_call_builder::EditorCallBuilder;
+use open_editor::EditorCallBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let filename = "./test";

--- a/examples/interactive_edit.rs
+++ b/examples/interactive_edit.rs
@@ -1,4 +1,4 @@
-use open_editor::editor_call_builder::EditorCallBuilder;
+use open_editor::EditorCallBuilder;
 use std::{
     io::{self, Write},
     process::exit,

--- a/src/editor_kind.rs
+++ b/src/editor_kind.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-#[derive(Default, Debug)]
-pub(crate) enum EditorKind {
+#[derive(Debug)]
+pub enum EditorKind {
     // CLI
     Vi,
     Vim,
@@ -14,14 +14,32 @@ pub(crate) enum EditorKind {
     // GUI
     Code,
     Gvim,
-    #[default]
-    UnknownEditor,
+    UnknownEditor(String),
 }
 
-impl From<String> for EditorKind {
+impl EditorKind {
+    /// Returns the editor name as a string.
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            EditorKind::Vi => "vi",
+            EditorKind::Vim => "vim",
+            EditorKind::Nvim => "nvim",
+            EditorKind::Emacs => "emacs",
+            EditorKind::Nano => "nano",
+            EditorKind::Pico => "pico",
+            EditorKind::Helix => "hx",
+            EditorKind::Kakoune => "kak",
+            EditorKind::Code => "code",
+            EditorKind::Gvim => "gvim",
+            EditorKind::UnknownEditor(name) => name.as_str(),
+        }
+    }
+}
+
+impl<T: AsRef<str>> From<T> for EditorKind {
     /// Convert a string to an [`EditorKind`].
-    fn from(value: String) -> Self {
-        match value.as_str() {
+    fn from(value: T) -> Self {
+        match value.as_ref() {
             "vi" => EditorKind::Vi,
             "vim" => EditorKind::Vim,
             "nvim" => EditorKind::Nvim,
@@ -32,7 +50,7 @@ impl From<String> for EditorKind {
             "kak" => EditorKind::Kakoune,
             "code" | "vscode" => EditorKind::Code,
             "gvim" => EditorKind::Gvim,
-            _ => EditorKind::UnknownEditor,
+            v => EditorKind::UnknownEditor(v.to_owned()),
         }
     }
 }
@@ -73,7 +91,7 @@ impl EditorKind {
             EditorKind::Gvim | EditorKind::Vi | EditorKind::Vim | EditorKind::Nvim => {
                 vec![format!("+call cursor({}, {})", line, column), path]
             }
-            EditorKind::UnknownEditor => vec![path],
+            EditorKind::UnknownEditor(_) => vec![path],
         }
     }
 }


### PR DESCRIPTION
This builds on, and modifies #1 to allow defining a specific editor to use. It makes a few types public, and changes the convenience methods to take an `EditOptions` to specify which editor or variables to use to open the editor.